### PR TITLE
chore: configure security_scan verification gate (closes #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,8 @@ jobs:
       - name: Lint
         run: dotnet format --verify-no-changes --no-restore
 
+      - name: Security scan
+        run: ./.specfuse/scripts/security-scan.sh
+
       - name: Release build
         run: dotnet build --no-restore --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ coverage/
 *.opencover.xml
 TestResults/
 
+# Security scan reports
+security-scan.json
+
 # IDE
 .vs/
 .vscode/

--- a/.specfuse/scripts/security-scan.sh
+++ b/.specfuse/scripts/security-scan.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Security scan gate for the component agent verification contract.
+#
+# Runs `dotnet list package --vulnerable --include-transitive`, emits the JSON
+# report to ./security-scan.json, and exits non-zero if any vulnerability of
+# severity High or Critical is present. Moderate/Low findings are recorded in
+# the report but do not fail the gate.
+#
+# Invoked both by the component agent verification skill (via the command
+# declared in .specfuse/verification.yml) and by CI (.github/workflows/ci.yml).
+# The two must stay aligned by design.
+
+set -euo pipefail
+
+REPORT_PATH="${REPORT_PATH:-./security-scan.json}"
+
+dotnet list package --vulnerable --include-transitive --format json > "$REPORT_PATH"
+
+python3 - "$REPORT_PATH" <<'PY'
+import json
+import sys
+
+report_path = sys.argv[1]
+with open(report_path) as f:
+    data = json.load(f)
+
+critical = []
+high = []
+for project in data.get("projects", []):
+    for framework in project.get("frameworks", []):
+        for key in ("topLevelPackages", "transitivePackages"):
+            for pkg in framework.get(key, []):
+                for vuln in pkg.get("vulnerabilities", []):
+                    severity = vuln.get("severity", "")
+                    entry = (
+                        f"{project['path']} :: "
+                        f"{pkg['id']}@{pkg['resolvedVersion']} "
+                        f"({severity}) -> {vuln.get('advisoryurl', '')}"
+                    )
+                    if severity == "Critical":
+                        critical.append(entry)
+                    elif severity == "High":
+                        high.append(entry)
+
+if critical or high:
+    print(
+        f"FAIL: {len(critical)} Critical, {len(high)} High "
+        f"vulnerabilities found",
+        file=sys.stderr,
+    )
+    for line in critical + high:
+        print(f"  - {line}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"PASS: 0 High or Critical vulnerabilities (report at {report_path})")
+PY

--- a/.specfuse/verification.yml
+++ b/.specfuse/verification.yml
@@ -4,10 +4,6 @@
 #
 # Six gates are declared. Order below is the execution order the skill uses:
 # cheaper gates fail fast, expensive gates run only once earlier ones pass.
-#
-# security_scan is marked `not_yet_configured` with a tracking issue per the
-# skill's convention. Tasks in this repo cannot pass verification until that
-# tracking issue closes and this gate is filled with a real scan command.
 
 tests:
   command: "dotnet test --no-build --nologo --verbosity normal"
@@ -25,8 +21,8 @@ lint:
   command: "dotnet format --verify-no-changes --no-restore"
 
 security_scan:
-  status: not_yet_configured
-  tracking_issue: Bontyyy/orchestrator-api-sample#1
+  command: "./.specfuse/scripts/security-scan.sh"
+  report_path: "./security-scan.json"
 
 build:
   command: "dotnet build --no-restore --configuration Release"

--- a/tests/OrchestratorApiSample.Tests/OrchestratorApiSample.Tests.csproj
+++ b/tests/OrchestratorApiSample.Tests/OrchestratorApiSample.Tests.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Replaces the `not_yet_configured` placeholder for the `security_scan` gate with a real OWASP-equivalent scan: `dotnet list package --vulnerable --include-transitive --format json`, wrapped in `./.specfuse/scripts/security-scan.sh` so the component agent verification skill and CI invoke the same command.
- Fails the gate on any **High** or **Critical** transitive or direct advisory. Moderate/Low findings are recorded in the JSON report but do not fail the gate.
- Bumps `Microsoft.NET.Test.Sdk` 17.6.0 → 17.11.1 and `xunit` 2.4.x → 2.9.2 to clear two pre-existing High-severity transitive advisories on the old `System.Net.Http` / `System.Text.RegularExpressions` 4.3.0 packages (GHSA-7jgj-8wvc-jh57, GHSA-cmhx-cq75-c4mj) that the gate would otherwise fail on.
- Closes #1.

## Context (why now)

This PR unblocks the Phase 1 walkthrough (WU 1.5) in the [orchestrator repo](https://github.com/clabonte/orchestrator). The component agent verification skill treats `status: not_yet_configured` as a failing gate — no agent task in this repo can pass verification until the gate is real. The walkthrough's Task A log documents this bootstrap discovery and links back here.

Landing this gate is **explicitly a human operator responsibility** per the skill: _"The only way to unblock is for the human to land the configuration change."_ Not an agent task.

## Test plan

- [ ] CI passes on this PR (the new Security scan step is itself the check).
- [ ] Locally: `dotnet build`, `dotnet test`, `dotnet format --verify-no-changes`, `./.specfuse/scripts/security-scan.sh` — all green.
- [ ] After merge, #1 auto-closes and the sample repo's `.specfuse/verification.yml` declares six real gates, no placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)