### PR TITLE
feat(widget): enforce maximum quantity of 10 000 on widget creation

### DIFF
--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -34,6 +34,11 @@ public sealed class WidgetService
             throw new ValidationException(nameof(quantity), "must be non-negative");
         }
 
+        if (quantity > 10_000)
+        {
+            throw new ValidationException(nameof(quantity), "must be at most 10000");
+        }
+
         var widget = new Widget(
             Id: Guid.NewGuid().ToString("N"),
             Name: name.Trim(),

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
@@ -80,6 +80,32 @@ public sealed class WidgetServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_with_quantity_above_ceiling_throws_ValidationException()
+    {
+        var service = new WidgetService(Mock.Of<IWidgetRepository>());
+
+        var act = () => service.CreateAsync("Gadget", "GAD-001", 10_001, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("quantity");
+        ex.Which.Reason.Should().Be("must be at most 10000");
+    }
+
+    [Fact]
+    public async Task CreateAsync_with_quantity_at_ceiling_is_allowed()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Widget w, CancellationToken _) => w);
+
+        var service = new WidgetService(repo.Object);
+
+        var widget = await service.CreateAsync("Gadget", "GAD-001", 10_000, CancellationToken.None);
+
+        widget.Quantity.Should().Be(10_000);
+    }
+
+    [Fact]
     public async Task CreateAsync_with_zero_quantity_is_allowed()
     {
         var repo = new Mock<IWidgetRepository>();


### PR DESCRIPTION
`FEAT-2026-0001/T01`

Implements the sole task of [FEAT-2026-0001 — Widget quantity ceiling](https://github.com/clabonte/orchestrator/blob/main/features/FEAT-2026-0001.md). Closes [#3](https://github.com/Bontyyy/orchestrator-api-sample/issues/3).

## Summary

- `WidgetService.CreateAsync` now rejects `quantity > 10_000` with `ValidationException("quantity", "must be at most 10000")`, mirroring the existing `quantity < 0` rule trait for trait.
- The ceiling is **inclusive**: `quantity == 10_000` is accepted.
- No public API surface change; no controller change; no domain change.
- 2 new unit tests (rejection above ceiling, acceptance at ceiling).

## Verification (run locally before PR open)

All six mandatory gates and both per-task verification commands passed on cycle 1 — no re-runs needed.

| Gate | Status | Evidence |
|---|---|---|
| `tests` | pass | 21/21 passed (19 existing + 2 new) |
| `coverage` | pass | line coverage 1.0000, branch coverage 1.0000 (threshold 0.90) |
| `compiler_warnings` | pass | 0 warnings |
| `lint` | pass | `dotnet format --verify-no-changes` clean |
| `security_scan` | pass | 0 High, 0 Critical advisories |
| `build` | pass | Release build green |

Per-task verification (from issue body):
- `dotnet test ... --filter "FullyQualifiedName~WidgetServiceTests"` → 17/17 passed
- `grep -F "must be at most 10000" src/.../WidgetService.cs` → match found on the exact line of the new rule

## Context

Opened by the v1 component agent as the implementation PR for Task A of the Phase 1 walkthrough (WU 1.5) in the orchestrator. The full walkthrough narrative — issue content, agent actions, gate evidence, gaps surfaced pre-Task-A — lives at [docs/walkthroughs/phase-1/task-A-log.md](https://github.com/clabonte/orchestrator/blob/main/docs/walkthroughs/phase-1/task-A-log.md) on the orchestrator repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
