### PR TITLE
feat(widget): add DELETE /widgets/{id} endpoint

### DIFF
--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -44,6 +44,21 @@ public sealed class WidgetsController : ControllerBase
 
         return widget is null ? NotFound() : Ok(widget);
     }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _service.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new { error = "validation_failed", field = ex.Field, reason = ex.Reason });
+        }
+    }
 }
 
 public sealed record CreateWidgetRequest(string Name, string Sku, int Quantity);

--- a/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
@@ -19,4 +19,10 @@ public sealed class InMemoryWidgetRepository : IWidgetRepository
         _store.TryGetValue(id, out var widget);
         return Task.FromResult(widget);
     }
+
+    public Task DeleteAsync(string id, CancellationToken cancellationToken)
+    {
+        _store.TryRemove(id, out _);
+        return Task.CompletedTask;
+    }
 }

--- a/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
@@ -7,4 +7,6 @@ public interface IWidgetRepository
     Task<Widget> AddAsync(Widget widget, CancellationToken cancellationToken);
 
     Task<Widget?> GetByIdAsync(string id, CancellationToken cancellationToken);
+
+    Task DeleteAsync(string id, CancellationToken cancellationToken);
 }

--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -57,4 +57,14 @@ public sealed class WidgetService
 
         return _repository.GetByIdAsync(id, cancellationToken);
     }
+
+    public Task DeleteAsync(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new ValidationException(nameof(id), "must not be empty");
+        }
+
+        return _repository.DeleteAsync(id, cancellationToken);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
@@ -161,4 +161,49 @@ public sealed class WidgetServiceTests
         var ex = await act.Should().ThrowAsync<ValidationException>();
         ex.Which.Field.Should().Be("id");
     }
+
+    [Fact]
+    public async Task DeleteAsync_with_known_id_delegates_to_repository()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.DeleteAsync("abc123", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new WidgetService(repo.Object);
+
+        await service.DeleteAsync("abc123", CancellationToken.None);
+
+        repo.Verify(r => r.DeleteAsync("abc123", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_with_unknown_id_is_idempotent_and_still_delegates()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.DeleteAsync("nonexistent", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        repo.Verify(r => r.DeleteAsync("nonexistent", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task DeleteAsync_with_blank_id_throws_ValidationException_and_skips_repository(string? id)
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.DeleteAsync(id!, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("id");
+        repo.Verify(r => r.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
@@ -65,4 +65,41 @@ public sealed class WidgetsControllerTests
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Which;
         ok.Value.Should().Be(createdWidget);
     }
+
+    [Fact]
+    public async Task Delete_with_existing_id_returns_NoContent_and_widget_is_gone()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("Gadget", "GAD-001", 5),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var deleteResult = await controller.Delete(createdWidget!.Id, CancellationToken.None);
+
+        deleteResult.Should().BeOfType<NoContentResult>();
+
+        var getResult = await controller.GetById(createdWidget.Id, CancellationToken.None);
+        getResult.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Delete_with_unknown_id_returns_NoContent_idempotently()
+    {
+        var controller = BuildController();
+
+        var deleteResult = await controller.Delete("nonexistent-id", CancellationToken.None);
+
+        deleteResult.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task Delete_with_blank_id_returns_BadRequest_with_field_info()
+    {
+        var controller = BuildController();
+
+        var deleteResult = await controller.Delete("   ", CancellationToken.None);
+
+        deleteResult.Should().BeOfType<BadRequestObjectResult>();
+    }
 }


### PR DESCRIPTION
Correlation ID: `FEAT-2026-0002/T01`

Closes [#5](https://github.com/Bontyyy/orchestrator-api-sample/issues/5).

## Summary

Adds `DELETE /widgets/{id}` as the third verb on the widget resource. Touches six files: port (`IWidgetRepository`), adapter (`InMemoryWidgetRepository`), service (`WidgetService`), controller (`WidgetsController`), service-level tests, and controller-level tests. All six mandatory verification gates pass on this branch and coverage remains at 1.0000 line / 1.0000 branch.

## Design decision: idempotent 204 on unknown id

The issue body pre-selected policy **A** (return `204 NoContent` whether or not the id exists) over policy **B** (return `404 NotFound` when unknown). I implemented A and I agree with the choice:

- REST idempotence is stronger with A — repeated `DELETE` on the same id produces the same observable result every time, matching the verb's RFC 9110 semantics.
- Less information leakage on arbitrary id probes — a strict 404 lets a caller distinguish "id exists but I can't delete it" from "id does not exist", which is a minor but real side channel on a future-authorized resource.
- The repository contract stays simpler — `DeleteAsync` has no return value and cannot signal "not found", which removes a failure-mode surface the service would otherwise have to collapse back into silent success anyway.

If a reviewer prefers policy B here, the change is mechanical: `InMemoryWidgetRepository.DeleteAsync` can return `bool` from `TryRemove`, service propagates, controller maps false → `NotFound()`. Happy to rework on request; per the issue body that does not trigger escalation.

## Walkthrough-specific note (to orchestrator PM)

The initial issue body excluded controller-level tests "by symmetry with the other widget endpoints, which also only have service-level tests in this repo." That claim was factually wrong — `WidgetsControllerTests.cs` already covers `Create` and `GetById`. Proceeding without `Delete` controller tests dropped line coverage from 1.0000 to 0.8604, below the 0.90 gate. The issue body was amended mid-task to correct the exclusion and three controller tests were added. This is the first PM-authored-issue-body friction surfaced by the Phase 1 walkthrough and should be recorded in the Task B log and WU 1.6 retrospective candidates.

## Verification

All six mandatory gates per `.specfuse/verification.yml`:

| Gate | Status | Evidence |
|---|---|---|
| tests | pass | 29/29 passed (24 existing + 5 new service + 3 new controller; note 22+7 total via per-class filters) |
| coverage | pass | line coverage 1.0000, branch coverage 1.0000 |
| compiler_warnings | pass | 0 warnings under `/warnaserror` |
| lint | pass | `dotnet format --verify-no-changes` clean |
| security_scan | pass | 0 High, 0 Critical advisories |
| build | pass | Release build succeeded, 0 warnings |

Per-task verification from the amended issue body:

- `dotnet test --filter "FullyQualifiedName~WidgetServiceTests"` — 22/22 passed
- `dotnet test --filter "FullyQualifiedName~WidgetsControllerTests"` — 7/7 passed
- `grep "HttpDelete" WidgetsController.cs` — match found
- `grep "DeleteAsync" IWidgetRepository.cs` — match found
- `grep "TryRemove" InMemoryWidgetRepository.cs` — match found

## Out-of-scope items (preserved per issue body)

No changes to `Widget`, `ValidationException`, existing `CreateAsync` / `GetByIdAsync` behavior, existing tests, `.specfuse/verification.yml`, CI workflow, `Program.cs`, csproj files, or branch protection.
