### PR TITLE
chore: add .specfuse/templates.yaml declaration

### DIFF
--- a/.specfuse/templates.yaml
+++ b/.specfuse/templates.yaml
@@ -1,0 +1,18 @@
+# Template coverage declaration for orchestrator-api-sample.
+#
+# Consumed by the orchestrator's PM template-coverage-check skill
+# (agents/pm/skills/template-coverage-check/SKILL.md) at feature-planning
+# time. Declares which generator-template categories this repo supports.
+#
+# Token vocabulary is free-form kebab-case at v1 — no central registry
+# until Phase 5. The tokens below match the api-sided tokens used in the
+# skill's worked examples.
+
+schema_version: 1
+
+provided_templates:
+  - api-controller
+  - api-request-validator
+  - api-response-serializer
+  - test-plan
+  - test-runner


### PR DESCRIPTION
## Summary

- Adds `.specfuse/templates.yaml` declaring the template-coverage tokens this repo provides (api-controller, api-request-validator, api-response-serializer, test-plan, test-runner).
- Consumed by the orchestrator's PM template-coverage-check skill (`agents/pm/skills/template-coverage-check/SKILL.md`) at feature-planning time.
- Required for the upcoming Phase 2 walkthrough (WU 2.7, orchestrator repo), whose Feature 1 happy path needs template-coverage-check to pass against this repo on main.

## Test plan

- [x] File validates against `shared/schemas/template-coverage.schema.json` in the orchestrator repo (`schema_version: 1`, `provided_templates` kebab-case).
- [x] No runtime impact on this repo — declaration file only, no CI or source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)