### PR TITLE
feat(widget): add GET /widgets/count endpoint

### DIFF
--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -45,6 +45,13 @@ public sealed class WidgetsController : ControllerBase
         return widget is null ? NotFound() : Ok(widget);
     }
 
+    [HttpGet("count")]
+    public async Task<IActionResult> GetCount(CancellationToken cancellationToken)
+    {
+        var count = await _service.GetCountAsync(cancellationToken);
+        return Ok(new { count });
+    }
+
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
     {

--- a/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
@@ -25,4 +25,9 @@ public sealed class InMemoryWidgetRepository : IWidgetRepository
         _store.TryRemove(id, out _);
         return Task.CompletedTask;
     }
+
+    public Task<int> CountAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_store.Count);
+    }
 }

--- a/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
@@ -9,4 +9,6 @@ public interface IWidgetRepository
     Task<Widget?> GetByIdAsync(string id, CancellationToken cancellationToken);
 
     Task DeleteAsync(string id, CancellationToken cancellationToken);
+
+    Task<int> CountAsync(CancellationToken cancellationToken);
 }

--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -67,4 +67,9 @@ public sealed class WidgetService
 
         return _repository.DeleteAsync(id, cancellationToken);
     }
+
+    public Task<int> GetCountAsync(CancellationToken cancellationToken)
+    {
+        return _repository.CountAsync(cancellationToken);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
@@ -206,4 +206,34 @@ public sealed class WidgetServiceTests
         ex.Which.Field.Should().Be("id");
         repo.Verify(r => r.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task GetCountAsync_with_zero_widgets_returns_zero()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.CountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var service = new WidgetService(repo.Object);
+
+        var count = await service.GetCountAsync(CancellationToken.None);
+
+        count.Should().Be(0);
+        repo.Verify(r => r.CountAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCountAsync_with_n_widgets_returns_n()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.CountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var service = new WidgetService(repo.Object);
+
+        var count = await service.GetCountAsync(CancellationToken.None);
+
+        count.Should().Be(3);
+        repo.Verify(r => r.CountAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
@@ -102,4 +102,28 @@ public sealed class WidgetsControllerTests
 
         deleteResult.Should().BeOfType<BadRequestObjectResult>();
     }
+
+    [Fact]
+    public async Task GetCount_with_empty_store_returns_Ok_with_count_zero()
+    {
+        var controller = BuildController();
+
+        var result = await controller.GetCount(CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        ok.Value.Should().BeEquivalentTo(new { count = 0 });
+    }
+
+    [Fact]
+    public async Task GetCount_after_creating_widgets_returns_Ok_with_correct_count()
+    {
+        var controller = BuildController();
+        await controller.Create(new CreateWidgetRequest("Widget A", "SKU-A", 1), CancellationToken.None);
+        await controller.Create(new CreateWidgetRequest("Widget B", "SKU-B", 2), CancellationToken.None);
+
+        var result = await controller.GetCount(CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        ok.Value.Should().BeEquivalentTo(new { count = 2 });
+    }
 }


### PR DESCRIPTION
FEAT-2026-0006/T01

## Summary

Adds the `GET /widgets/count` endpoint that returns `{"count": N}` where N is the number of widgets currently held in the in-memory store. Extends `IWidgetRepository` with `CountAsync`, implements it via `ConcurrentDictionary.Count` in `InMemoryWidgetRepository`, delegates through `WidgetService.GetCountAsync`, and maps a new `GetCount` action on `WidgetsController` at `[HttpGet("count")]`.

## Task

- Issue: Bontyyy/orchestrator-api-sample#13
- Feature: FEAT-2026-0006

## Verification

All six mandatory gates passing. Evidence in the `task_completed` event payload on the orchestration repo's `/events/FEAT-2026-0006.jsonl`.

- tests: pass (33/33 passed)
- coverage: 1.00 (threshold 0.90)
- compiler_warnings: pass (0 warnings)
- lint: pass
- security_scan: pass (0 high, 0 critical)
- build: pass (Release build clean)

## Spec issues raised during execution

none

## Overrides applied

none

Closes #13