### PR TITLE
feat(api): add paginated GET /widgets endpoint

### DIFF
--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -16,14 +16,14 @@ public sealed class WidgetsController : ControllerBase
         _service = service;
     }
 
-    private const int DefaultPageSize = 50;
+    private const int _defaultPageSize = 50;
 
     [HttpGet]
     public async Task<IActionResult> GetList(
         [FromQuery(Name = "page_size")] int? pageSize,
         CancellationToken cancellationToken)
     {
-        var effectivePageSize = pageSize ?? DefaultPageSize;
+        var effectivePageSize = pageSize ?? _defaultPageSize;
 
         try
         {

--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -16,6 +16,33 @@ public sealed class WidgetsController : ControllerBase
         _service = service;
     }
 
+    private const int DefaultPageSize = 50;
+
+    [HttpGet]
+    public async Task<IActionResult> GetList(
+        [FromQuery(Name = "page_size")] int? pageSize,
+        CancellationToken cancellationToken)
+    {
+        var effectivePageSize = pageSize ?? DefaultPageSize;
+
+        try
+        {
+            var widgets = await _service.GetListAsync(effectivePageSize, cancellationToken);
+            return Ok(widgets);
+        }
+        catch (ValidationException)
+        {
+            return BadRequest(new
+            {
+                error = new
+                {
+                    code = "page_size_over_limit",
+                    message = $"page_size must be between 1 and 500; received {effectivePageSize}.",
+                },
+            });
+        }
+    }
+
     [HttpPost]
     public async Task<ActionResult<Widget>> Create(
         [FromBody] CreateWidgetRequest request,

--- a/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
@@ -30,4 +30,10 @@ public sealed class InMemoryWidgetRepository : IWidgetRepository
     {
         return Task.FromResult(_store.Count);
     }
+
+    public Task<IReadOnlyList<Widget>> GetListAsync(int pageSize, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<Widget> result = _store.Values.Take(pageSize).ToList();
+        return Task.FromResult(result);
+    }
 }

--- a/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
@@ -11,4 +11,6 @@ public interface IWidgetRepository
     Task DeleteAsync(string id, CancellationToken cancellationToken);
 
     Task<int> CountAsync(CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Widget>> GetListAsync(int pageSize, CancellationToken cancellationToken);
 }

--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -72,4 +72,14 @@ public sealed class WidgetService
     {
         return _repository.CountAsync(cancellationToken);
     }
+
+    public Task<IReadOnlyList<Widget>> GetListAsync(int pageSize, CancellationToken cancellationToken)
+    {
+        if (pageSize > 500)
+        {
+            throw new ValidationException(nameof(pageSize), "must be at most 500");
+        }
+
+        return _repository.GetListAsync(pageSize, cancellationToken);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
@@ -236,4 +236,40 @@ public sealed class WidgetServiceTests
         count.Should().Be(3);
         repo.Verify(r => r.CountAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // AC-1 / AC-2: valid page sizes delegate to repository
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(500)]
+    public async Task GetListAsync_with_valid_page_size_delegates_to_repository(int pageSize)
+    {
+        IReadOnlyList<Widget> stored = new List<Widget> { new Widget("id1", "W", "SKU", 1) };
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.GetListAsync(pageSize, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.GetListAsync(pageSize, CancellationToken.None);
+
+        result.Should().BeSameAs(stored);
+        repo.Verify(r => r.GetListAsync(pageSize, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // AC-3: page_size > 500 throws ValidationException before hitting repository
+    [Theory]
+    [InlineData(501)]
+    [InlineData(1000)]
+    public async Task GetListAsync_with_page_size_over_500_throws_ValidationException(int pageSize)
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.GetListAsync(pageSize, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("pageSize");
+        repo.Verify(r => r.GetListAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
@@ -126,4 +126,92 @@ public sealed class WidgetsControllerTests
         var ok = result.Should().BeOfType<OkObjectResult>().Which;
         ok.Value.Should().BeEquivalentTo(new { count = 2 });
     }
+
+    // AC-1: no page_size → returns HTTP 200 with up to 50 widgets
+    [Fact]
+    public async Task GetList_without_page_size_returns_Ok_with_up_to_50_widgets()
+    {
+        var controller = BuildController();
+        for (var i = 0; i < 60; i++)
+        {
+            await controller.Create(new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i), CancellationToken.None);
+        }
+
+        var result = await controller.GetList(pageSize: null, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widgets = ok.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(50);
+    }
+
+    [Fact]
+    public async Task GetList_without_page_size_returns_Ok_when_fewer_than_50_widgets_exist()
+    {
+        var controller = BuildController();
+        await controller.Create(new CreateWidgetRequest("Widget A", "SKU-A", 1), CancellationToken.None);
+        await controller.Create(new CreateWidgetRequest("Widget B", "SKU-B", 2), CancellationToken.None);
+
+        var result = await controller.GetList(pageSize: null, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widgets = ok.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(2);
+    }
+
+    // AC-2: page_size=N with 1 ≤ N ≤ 500 → returns HTTP 200 with up to N widgets
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(500)]
+    public async Task GetList_with_valid_page_size_returns_Ok_with_up_to_N_widgets(int pageSize)
+    {
+        var controller = BuildController();
+        for (var i = 0; i < 10; i++)
+        {
+            await controller.Create(new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i), CancellationToken.None);
+        }
+
+        var result = await controller.GetList(pageSize: pageSize, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widgets = ok.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Count.Should().BeLessThanOrEqualTo(pageSize);
+    }
+
+    [Fact]
+    public async Task GetList_with_page_size_10_returns_exactly_10_when_more_exist()
+    {
+        var controller = BuildController();
+        for (var i = 0; i < 20; i++)
+        {
+            await controller.Create(new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i), CancellationToken.None);
+        }
+
+        var result = await controller.GetList(pageSize: 10, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widgets = ok.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(10);
+    }
+
+    // AC-3: page_size > 500 → returns HTTP 400 with {"error": {"code": "page_size_over_limit", ...}}
+    [Theory]
+    [InlineData(501)]
+    [InlineData(1000)]
+    [InlineData(int.MaxValue)]
+    public async Task GetList_with_page_size_over_500_returns_BadRequest_with_page_size_over_limit_code(int pageSize)
+    {
+        var controller = BuildController();
+
+        var result = await controller.GetList(pageSize: pageSize, CancellationToken.None);
+
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Which;
+        var body = badRequest.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        errorProp.Should().NotBeNull();
+        var errorValue = errorProp!.GetValue(body)!;
+        var codeProp = errorValue.GetType().GetProperty("code");
+        codeProp.Should().NotBeNull();
+        codeProp!.GetValue(errorValue).Should().Be("page_size_over_limit");
+    }
 }


### PR DESCRIPTION
FEAT-2026-0007/T01

## Summary

Adds the `GET /widgets` listing endpoint with `page_size` pagination. When `page_size` is omitted, returns up to 50 widgets (AC-1). When `page_size` is in range 1–500, returns up to N widgets (AC-2). When `page_size` exceeds 500, returns HTTP 400 with `error.code = "page_size_over_limit"` (AC-3).

## Task

- Issue: Bontyyy/orchestrator-api-sample#18
- Feature: FEAT-2026-0007 (Widgets list with pagination)

## Verification

All six mandatory gates passing. Evidence in the `task_completed` event payload on the orchestration repo's `/events/FEAT-2026-0007.jsonl`.

- tests: pass (47/47)
- coverage: pass (100.0%, threshold 0.90)
- compiler_warnings: pass (0 warnings)
- lint: pass
- security_scan: pass (0 high, 0 critical)
- build: pass (Release)

## Spec issues raised during execution

none

## Overrides applied

none

Closes Bontyyy/orchestrator-api-sample#18