### PR TITLE
[FEAT-2026-0008/T01] Implement PATCH /widgets/:id endpoint

### DIFF
--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -93,6 +93,43 @@ public sealed class WidgetsController : ControllerBase
             return BadRequest(new { error = "validation_failed", field = ex.Field, reason = ex.Reason });
         }
     }
+
+    [HttpPatch("{id}")]
+    public async Task<IActionResult> Update(
+        string id,
+        [FromBody] UpdateWidgetRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var widget = await _service.UpdateAsync(
+                id,
+                request.Name,
+                request.Sku,
+                request.Quantity,
+                cancellationToken);
+
+            if (widget is null)
+            {
+                return NotFound(new
+                {
+                    error = new
+                    {
+                        code = "widget_not_found",
+                        message = $"Widget with id '{id}' was not found.",
+                    },
+                });
+            }
+
+            return Ok(widget);
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new { error = "validation_failed", field = ex.Field, reason = ex.Reason });
+        }
+    }
 }
 
 public sealed record CreateWidgetRequest(string Name, string Sku, int Quantity);
+
+public sealed record UpdateWidgetRequest(string? Name, string? Sku, int? Quantity);

--- a/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Api/Persistence/InMemoryWidgetRepository.cs
@@ -36,4 +36,22 @@ public sealed class InMemoryWidgetRepository : IWidgetRepository
         IReadOnlyList<Widget> result = _store.Values.Take(pageSize).ToList();
         return Task.FromResult(result);
     }
+
+    public Task<Widget?> UpdateAsync(string id, string? name, string? sku, int? quantity, CancellationToken cancellationToken)
+    {
+        if (!_store.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult<Widget?>(null);
+        }
+
+        var updated = existing with
+        {
+            Name = name ?? existing.Name,
+            Sku = sku ?? existing.Sku,
+            Quantity = quantity ?? existing.Quantity,
+        };
+
+        _store[id] = updated;
+        return Task.FromResult<Widget?>(updated);
+    }
 }

--- a/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
+++ b/src/OrchestratorApiSample.Application/Interfaces/IWidgetRepository.cs
@@ -13,4 +13,6 @@ public interface IWidgetRepository
     Task<int> CountAsync(CancellationToken cancellationToken);
 
     Task<IReadOnlyList<Widget>> GetListAsync(int pageSize, CancellationToken cancellationToken);
+
+    Task<Widget?> UpdateAsync(string id, string? name, string? sku, int? quantity, CancellationToken cancellationToken);
 }

--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -82,4 +82,37 @@ public sealed class WidgetService
 
         return _repository.GetListAsync(pageSize, cancellationToken);
     }
+
+    public Task<Widget?> UpdateAsync(
+        string id,
+        string? name,
+        string? sku,
+        int? quantity,
+        CancellationToken cancellationToken)
+    {
+        if (name is not null && string.IsNullOrWhiteSpace(name))
+        {
+            throw new ValidationException(nameof(name), "must not be empty");
+        }
+
+        if (sku is not null && string.IsNullOrWhiteSpace(sku))
+        {
+            throw new ValidationException(nameof(sku), "must not be empty");
+        }
+
+        if (quantity is not null && quantity < 0)
+        {
+            throw new ValidationException(nameof(quantity), "must be non-negative");
+        }
+
+        if (quantity is not null && quantity > 10_000)
+        {
+            throw new ValidationException(nameof(quantity), "must be at most 10000");
+        }
+
+        var resolvedName = name?.Trim();
+        var resolvedSku = sku?.Trim();
+
+        return _repository.UpdateAsync(id, resolvedName, resolvedSku, quantity, cancellationToken);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceTests.cs
@@ -272,4 +272,159 @@ public sealed class WidgetServiceTests
         ex.Which.Field.Should().Be("pageSize");
         repo.Verify(r => r.GetListAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    // UpdateAsync — valid partial updates delegate to repository and return updated widget
+    [Fact]
+    public async Task UpdateAsync_name_only_updates_name_and_leaves_other_fields_unchanged()
+    {
+        var existing = new Widget("id1", "OldName", "SKU-001", 5);
+        var updated = existing with { Name = "NewName" };
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync("id1", "NewName", null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("id1", "NewName", null, null, CancellationToken.None);
+
+        result.Should().Be(updated);
+        repo.Verify(r => r.UpdateAsync("id1", "NewName", null, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_sku_only_updates_sku_and_leaves_other_fields_unchanged()
+    {
+        var existing = new Widget("id1", "Name", "OLD-SKU", 5);
+        var updated = existing with { Sku = "NEW-SKU" };
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync("id1", null, "NEW-SKU", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("id1", null, "NEW-SKU", null, CancellationToken.None);
+
+        result.Should().Be(updated);
+        repo.Verify(r => r.UpdateAsync("id1", null, "NEW-SKU", null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_quantity_only_updates_quantity_and_leaves_other_fields_unchanged()
+    {
+        var existing = new Widget("id1", "Name", "SKU-001", 5);
+        var updated = existing with { Quantity = 42 };
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync("id1", null, null, 42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("id1", null, null, 42, CancellationToken.None);
+
+        result.Should().Be(updated);
+        repo.Verify(r => r.UpdateAsync("id1", null, null, 42, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_all_fields_updates_all_fields()
+    {
+        var updated = new Widget("id1", "NewName", "NEW-SKU", 100);
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync("id1", "NewName", "NEW-SKU", 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("id1", "NewName", "NEW-SKU", 100, CancellationToken.None);
+
+        result.Should().Be(updated);
+        repo.Verify(r => r.UpdateAsync("id1", "NewName", "NEW-SKU", 100, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_with_unknown_id_returns_null()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Widget?)null);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("nonexistent", "NewName", null, null, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateAsync_with_blank_name_throws_ValidationException_before_hitting_repository(string name)
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.UpdateAsync("id1", name, null, null, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("name");
+        repo.Verify(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateAsync_with_blank_sku_throws_ValidationException_before_hitting_repository(string sku)
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.UpdateAsync("id1", null, sku, null, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("sku");
+        repo.Verify(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_with_negative_quantity_throws_ValidationException_before_hitting_repository()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.UpdateAsync("id1", null, null, -1, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("quantity");
+        repo.Verify(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_with_quantity_above_ceiling_throws_ValidationException_before_hitting_repository()
+    {
+        var repo = new Mock<IWidgetRepository>();
+        var service = new WidgetService(repo.Object);
+
+        var act = () => service.UpdateAsync("id1", null, null, 10_001, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Field.Should().Be("quantity");
+        ex.Which.Reason.Should().Be("must be at most 10000");
+        repo.Verify(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_trims_whitespace_from_name_when_provided()
+    {
+        var updated = new Widget("id1", "NewName", "SKU-001", 5);
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.UpdateAsync("id1", "NewName", null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var service = new WidgetService(repo.Object);
+
+        var result = await service.UpdateAsync("id1", "  NewName  ", null, null, CancellationToken.None);
+
+        result.Should().Be(updated);
+        repo.Verify(r => r.UpdateAsync("id1", "NewName", null, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetsControllerTests.cs
@@ -214,4 +214,128 @@ public sealed class WidgetsControllerTests
         codeProp.Should().NotBeNull();
         codeProp!.GetValue(errorValue).Should().Be("page_size_over_limit");
     }
+
+    // PATCH /widgets/:id — AC-1: valid partial update returns 200 with updated widget
+    [Fact]
+    public async Task Update_with_name_only_returns_Ok_with_updated_widget()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("OriginalName", "SKU-001", 10),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var result = await controller.Update(
+            createdWidget!.Id,
+            new UpdateWidgetRequest("UpdatedName", null, null),
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widget = ok.Value.Should().BeOfType<Widget>().Which;
+        widget.Name.Should().Be("UpdatedName");
+        widget.Sku.Should().Be("SKU-001");
+        widget.Quantity.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task Update_with_sku_only_returns_Ok_with_updated_widget()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("Name", "OLD-SKU", 10),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var result = await controller.Update(
+            createdWidget!.Id,
+            new UpdateWidgetRequest(null, "NEW-SKU", null),
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widget = ok.Value.Should().BeOfType<Widget>().Which;
+        widget.Name.Should().Be("Name");
+        widget.Sku.Should().Be("NEW-SKU");
+        widget.Quantity.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task Update_with_quantity_only_returns_Ok_with_updated_widget()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("Name", "SKU-001", 5),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var result = await controller.Update(
+            createdWidget!.Id,
+            new UpdateWidgetRequest(null, null, 999),
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widget = ok.Value.Should().BeOfType<Widget>().Which;
+        widget.Name.Should().Be("Name");
+        widget.Sku.Should().Be("SKU-001");
+        widget.Quantity.Should().Be(999);
+    }
+
+    [Fact]
+    public async Task Update_with_all_fields_returns_Ok_with_all_fields_updated()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("OldName", "OLD-SKU", 1),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var result = await controller.Update(
+            createdWidget!.Id,
+            new UpdateWidgetRequest("NewName", "NEW-SKU", 42),
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var widget = ok.Value.Should().BeOfType<Widget>().Which;
+        widget.Name.Should().Be("NewName");
+        widget.Sku.Should().Be("NEW-SKU");
+        widget.Quantity.Should().Be(42);
+    }
+
+    // PATCH /widgets/:id — AC-2: unknown id returns 404 with error.code == "widget_not_found"
+    [Fact]
+    public async Task Update_with_unknown_id_returns_NotFound_with_widget_not_found_code()
+    {
+        var controller = BuildController();
+
+        var result = await controller.Update(
+            "nonexistent-id",
+            new UpdateWidgetRequest("NewName", null, null),
+            CancellationToken.None);
+
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Which;
+        var body = notFound.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        errorProp.Should().NotBeNull();
+        var errorValue = errorProp!.GetValue(body)!;
+        var codeProp = errorValue.GetType().GetProperty("code");
+        codeProp.Should().NotBeNull();
+        codeProp!.GetValue(errorValue).Should().Be("widget_not_found");
+    }
+
+    // PATCH /widgets/:id — AC-3 (via issue): validation failure returns 400
+    [Fact]
+    public async Task Update_with_blank_name_returns_BadRequest_with_field_info()
+    {
+        var controller = BuildController();
+        var createResult = await controller.Create(
+            new CreateWidgetRequest("Name", "SKU-001", 5),
+            CancellationToken.None);
+        var createdWidget = ((CreatedAtActionResult)createResult.Result!).Value as Widget;
+
+        var result = await controller.Update(
+            createdWidget!.Id,
+            new UpdateWidgetRequest("", null, null),
+            CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `PATCH /widgets/:id` endpoint with partial-update semantics
- AC-1: valid partial body returns 200 + full updated widget
- AC-2: non-existent ID returns 404 + `widget_not_found` error code

## Verification
- 65/65 tests pass (11 new service tests + 6 new controller tests)
- 100% line coverage
- All 6 gates green

Feature: FEAT-2026-0008/T01