### PR TITLE
feat(api): add POST /widgets/bulk endpoint with atomic batch validation

### DIFF
--- a/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
+++ b/src/OrchestratorApiSample.Api/Controllers/WidgetsController.cs
@@ -94,6 +94,46 @@ public sealed class WidgetsController : ControllerBase
         }
     }
 
+    [HttpPost("bulk")]
+    public async Task<IActionResult> BulkCreate(
+        [FromBody] IReadOnlyList<CreateWidgetRequest> requests,
+        CancellationToken cancellationToken)
+    {
+        var items = requests
+            .Select(r => new BulkCreateItem(r.Name, r.Sku, r.Quantity))
+            .ToList();
+
+        var result = await _service.BulkCreateAsync(items, cancellationToken);
+
+        return result.ResultOutcome switch
+        {
+            BulkCreateResult.Outcome.Created =>
+                StatusCode(201, result.CreatedWidgets),
+
+            BulkCreateResult.Outcome.BatchSizeExceeded =>
+                BadRequest(new
+                {
+                    error = new
+                    {
+                        code = "batch_size_exceeded",
+                        message = $"Batch size of {result.ReceivedCount} exceeds the maximum allowed limit of {result.MaxAllowed} items.",
+                    },
+                }),
+
+            BulkCreateResult.Outcome.ValidationFailure =>
+                UnprocessableEntity(new
+                {
+                    error = new
+                    {
+                        code = "batch_validation_failure",
+                        failures = result.Failures.Select(f => new { index = f.Index, reason = f.Reason }).ToArray(),
+                    },
+                }),
+
+            _ => StatusCode(500),
+        };
+    }
+
     [HttpPatch("{id}")]
     public async Task<IActionResult> Update(
         string id,

--- a/src/OrchestratorApiSample.Application/Services/BulkCreateFailure.cs
+++ b/src/OrchestratorApiSample.Application/Services/BulkCreateFailure.cs
@@ -1,0 +1,8 @@
+namespace OrchestratorApiSample.Application.Services;
+
+/// <summary>
+/// Describes a single validation failure within a bulk creation request.
+/// </summary>
+/// <param name="Index">Zero-based position of the failing item in the input array.</param>
+/// <param name="Reason">Human-readable description of why validation failed.</param>
+public sealed record BulkCreateFailure(int Index, string Reason);

--- a/src/OrchestratorApiSample.Application/Services/BulkCreateItem.cs
+++ b/src/OrchestratorApiSample.Application/Services/BulkCreateItem.cs
@@ -1,0 +1,6 @@
+namespace OrchestratorApiSample.Application.Services;
+
+/// <summary>
+/// Represents a single item in a bulk widget creation request.
+/// </summary>
+public sealed record BulkCreateItem(string Name, string Sku, int Quantity);

--- a/src/OrchestratorApiSample.Application/Services/BulkCreateResult.cs
+++ b/src/OrchestratorApiSample.Application/Services/BulkCreateResult.cs
@@ -1,0 +1,41 @@
+using OrchestratorApiSample.Domain;
+
+namespace OrchestratorApiSample.Application.Services;
+
+/// <summary>
+/// Discriminated union result returned by <see cref="WidgetService.BulkCreateAsync"/>.
+/// </summary>
+public sealed class BulkCreateResult
+{
+    private BulkCreateResult() { }
+
+    public enum Outcome
+    {
+        Created,
+        BatchSizeExceeded,
+        ValidationFailure,
+    }
+
+    public Outcome ResultOutcome { get; private init; }
+
+    /// <summary>Set when <see cref="ResultOutcome"/> is <see cref="Outcome.Created"/>.</summary>
+    public IReadOnlyList<Widget> CreatedWidgets { get; private init; } = [];
+
+    /// <summary>Set when <see cref="ResultOutcome"/> is <see cref="Outcome.ValidationFailure"/>.</summary>
+    public IReadOnlyList<BulkCreateFailure> Failures { get; private init; } = [];
+
+    /// <summary>Set when <see cref="ResultOutcome"/> is <see cref="Outcome.BatchSizeExceeded"/>.</summary>
+    public int ReceivedCount { get; private init; }
+
+    /// <summary>Set when <see cref="ResultOutcome"/> is <see cref="Outcome.BatchSizeExceeded"/>.</summary>
+    public int MaxAllowed { get; private init; }
+
+    public static BulkCreateResult Success(IReadOnlyList<Widget> widgets) =>
+        new() { ResultOutcome = Outcome.Created, CreatedWidgets = widgets };
+
+    public static BulkCreateResult BatchSizeExceeded(int received, int max) =>
+        new() { ResultOutcome = Outcome.BatchSizeExceeded, ReceivedCount = received, MaxAllowed = max };
+
+    public static BulkCreateResult ValidationFailure(IReadOnlyList<BulkCreateFailure> failures) =>
+        new() { ResultOutcome = Outcome.ValidationFailure, Failures = failures };
+}

--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -83,6 +83,66 @@ public sealed class WidgetService
         return _repository.GetListAsync(pageSize, cancellationToken);
     }
 
+    public const int BulkCreateMaxBatchSize = 50;
+
+    /// <summary>
+    /// Validates all items first (atomically) and, if all pass, persists them all.
+    /// Returns a <see cref="BulkCreateResult"/> that distinguishes three outcomes:
+    /// batch-size overflow, validation failure, and success.
+    /// </summary>
+    public async Task<BulkCreateResult> BulkCreateAsync(
+        IReadOnlyList<BulkCreateItem> items,
+        CancellationToken cancellationToken)
+    {
+        if (items.Count > BulkCreateMaxBatchSize)
+        {
+            return BulkCreateResult.BatchSizeExceeded(items.Count, BulkCreateMaxBatchSize);
+        }
+
+        // Validate all items first — atomicity requires no persistence on any failure.
+        var failures = new List<BulkCreateFailure>();
+        for (var i = 0; i < items.Count; i++)
+        {
+            var item = items[i];
+            if (string.IsNullOrWhiteSpace(item.Name))
+            {
+                failures.Add(new BulkCreateFailure(i, "name must not be empty"));
+            }
+            else if (string.IsNullOrWhiteSpace(item.Sku))
+            {
+                failures.Add(new BulkCreateFailure(i, "sku must not be empty"));
+            }
+            else if (item.Quantity < 0)
+            {
+                failures.Add(new BulkCreateFailure(i, "quantity must be non-negative"));
+            }
+            else if (item.Quantity > 10_000)
+            {
+                failures.Add(new BulkCreateFailure(i, "quantity must be at most 10000"));
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            return BulkCreateResult.ValidationFailure(failures);
+        }
+
+        // All items validated — persist them all.
+        var created = new List<Widget>(items.Count);
+        foreach (var item in items)
+        {
+            var widget = new Widget(
+                Id: Guid.NewGuid().ToString("N"),
+                Name: item.Name.Trim(),
+                Sku: item.Sku.Trim(),
+                Quantity: item.Quantity);
+            var stored = await _repository.AddAsync(widget, cancellationToken);
+            created.Add(stored);
+        }
+
+        return BulkCreateResult.Success(created);
+    }
+
     public Task<Widget?> UpdateAsync(
         string id,
         string? name,

--- a/tests/OrchestratorApiSample.Tests/WidgetServiceBulkTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetServiceBulkTests.cs
@@ -1,0 +1,251 @@
+using OrchestratorApiSample.Application.Interfaces;
+using OrchestratorApiSample.Application.Services;
+using OrchestratorApiSample.Domain;
+
+namespace OrchestratorApiSample.Tests;
+
+public sealed class WidgetServiceBulkTests
+{
+    private static WidgetService BuildService(Mock<IWidgetRepository>? repoMock = null)
+    {
+        if (repoMock is null)
+        {
+            var mock = new Mock<IWidgetRepository>();
+            mock.Setup(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Widget w, CancellationToken _) => w);
+            return new WidgetService(mock.Object);
+        }
+
+        return new WidgetService(repoMock.Object);
+    }
+
+    // AC-1 / AC-5: happy path — all valid items are persisted and returned
+    [Fact]
+    public async Task BulkCreateAsync_with_all_valid_items_returns_Created_outcome()
+    {
+        var items = new List<BulkCreateItem>
+        {
+            new("Widget A", "SKU-A", 1),
+            new("Widget B", "SKU-B", 2),
+            new("Widget C", "SKU-C", 0),
+        };
+
+        var service = BuildService();
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.Created);
+        result.CreatedWidgets.Should().HaveCount(3);
+        result.CreatedWidgets.Should().OnlyContain(w => !string.IsNullOrWhiteSpace(w.Id));
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_with_single_valid_item_returns_Created_outcome()
+    {
+        var items = new List<BulkCreateItem> { new("Gadget", "GAD-001", 5) };
+        var service = BuildService();
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.Created);
+        result.CreatedWidgets.Should().HaveCount(1);
+        result.CreatedWidgets[0].Name.Should().Be("Gadget");
+        result.CreatedWidgets[0].Sku.Should().Be("GAD-001");
+        result.CreatedWidgets[0].Quantity.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_with_exactly_50_valid_items_returns_Created_outcome()
+    {
+        var items = Enumerable.Range(1, 50)
+            .Select(i => new BulkCreateItem($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var service = BuildService();
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.Created);
+        result.CreatedWidgets.Should().HaveCount(50);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_trims_whitespace_from_name_and_sku()
+    {
+        var items = new List<BulkCreateItem> { new("  Gadget  ", "  GAD-001  ", 5) };
+        var service = BuildService();
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.Created);
+        result.CreatedWidgets[0].Name.Should().Be("Gadget");
+        result.CreatedWidgets[0].Sku.Should().Be("GAD-001");
+    }
+
+    // AC-2 / AC-5: batch exceeding 50 items is rejected before any validation or persistence
+    [Fact]
+    public async Task BulkCreateAsync_with_51_items_returns_BatchSizeExceeded_outcome()
+    {
+        var items = Enumerable.Range(1, 51)
+            .Select(i => new BulkCreateItem($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.BatchSizeExceeded);
+        result.ReceivedCount.Should().Be(51);
+        result.MaxAllowed.Should().Be(50);
+        // No persistence must have occurred
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(51)]
+    [InlineData(100)]
+    public async Task BulkCreateAsync_with_batch_exceeding_max_returns_BatchSizeExceeded_outcome(int count)
+    {
+        var items = Enumerable.Range(1, count)
+            .Select(i => new BulkCreateItem($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.BatchSizeExceeded);
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // AC-3 / AC-5: any item failing validation causes BatchValidationFailure and zero persistence
+    [Fact]
+    public async Task BulkCreateAsync_with_one_invalid_item_returns_ValidationFailure_with_correct_index()
+    {
+        // Item at index 1 has blank name
+        var items = new List<BulkCreateItem>
+        {
+            new("Valid Widget", "SKU-001", 5),
+            new("", "SKU-002", 5),        // blank name — index 1
+            new("Another Widget", "SKU-003", 5),
+        };
+
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures.Should().HaveCount(1);
+        result.Failures[0].Index.Should().Be(1);
+        result.Failures[0].Reason.Should().NotBeNullOrWhiteSpace();
+        // No persistence must have occurred
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_with_multiple_invalid_items_returns_all_failures()
+    {
+        var items = new List<BulkCreateItem>
+        {
+            new("Valid Widget", "SKU-001", 5),
+            new("", "SKU-002", 5),         // blank name — index 1
+            new("Widget", "", 5),           // blank sku — index 2
+            new("Widget", "SKU-004", -1),   // negative quantity — index 3
+        };
+
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures.Should().HaveCount(3);
+        result.Failures.Select(f => f.Index).Should().BeEquivalentTo(new[] { 1, 2, 3 });
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BulkCreateAsync_with_blank_name_returns_ValidationFailure_at_correct_index(string name)
+    {
+        var items = new List<BulkCreateItem> { new(name, "SKU-001", 5) };
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures.Should().HaveCount(1);
+        result.Failures[0].Index.Should().Be(0);
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BulkCreateAsync_with_blank_sku_returns_ValidationFailure_at_correct_index(string sku)
+    {
+        var items = new List<BulkCreateItem> { new("Widget", sku, 5) };
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures.Should().HaveCount(1);
+        result.Failures[0].Index.Should().Be(0);
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_with_negative_quantity_returns_ValidationFailure()
+    {
+        var items = new List<BulkCreateItem> { new("Widget", "SKU-001", -1) };
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures[0].Index.Should().Be(0);
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_with_quantity_above_ceiling_returns_ValidationFailure()
+    {
+        var items = new List<BulkCreateItem> { new("Widget", "SKU-001", 10_001) };
+        var repo = new Mock<IWidgetRepository>();
+        var service = BuildService(repo);
+
+        var result = await service.BulkCreateAsync(items, CancellationToken.None);
+
+        result.ResultOutcome.Should().Be(BulkCreateResult.Outcome.ValidationFailure);
+        result.Failures[0].Index.Should().Be(0);
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_calls_AddAsync_for_each_valid_item()
+    {
+        var items = new List<BulkCreateItem>
+        {
+            new("Widget A", "SKU-A", 1),
+            new("Widget B", "SKU-B", 2),
+        };
+
+        var repo = new Mock<IWidgetRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Widget w, CancellationToken _) => w);
+
+        var service = BuildService(repo);
+
+        await service.BulkCreateAsync(items, CancellationToken.None);
+
+        repo.Verify(r => r.AddAsync(It.IsAny<Widget>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/tests/OrchestratorApiSample.Tests/WidgetsControllerBulkTests.cs
+++ b/tests/OrchestratorApiSample.Tests/WidgetsControllerBulkTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.AspNetCore.Mvc;
+using OrchestratorApiSample.Api.Controllers;
+using OrchestratorApiSample.Api.Persistence;
+using OrchestratorApiSample.Application.Services;
+using OrchestratorApiSample.Domain;
+
+namespace OrchestratorApiSample.Tests;
+
+public sealed class WidgetsControllerBulkTests
+{
+    private static WidgetsController BuildController()
+    {
+        var repo = new InMemoryWidgetRepository();
+        var service = new WidgetService(repo);
+        return new WidgetsController(service);
+    }
+
+    // AC-1 / AC-6: valid batch returns 201 with array body containing all created widgets
+    [Fact]
+    public async Task BulkCreate_with_valid_batch_returns_201_with_created_widgets()
+    {
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest>
+        {
+            new("Widget A", "SKU-A", 1),
+            new("Widget B", "SKU-B", 2),
+            new("Widget C", "SKU-C", 0),
+        };
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var statusResult = result.Should().BeOfType<ObjectResult>().Which;
+        statusResult.StatusCode.Should().Be(201);
+        var widgets = statusResult.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(3);
+        widgets.Should().OnlyContain(w => !string.IsNullOrWhiteSpace(w.Id));
+        widgets.Select(w => w.Name).Should().BeEquivalentTo("Widget A", "Widget B", "Widget C");
+    }
+
+    [Fact]
+    public async Task BulkCreate_with_single_valid_item_returns_201_with_single_element_array()
+    {
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest> { new("Gadget", "GAD-001", 5) };
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var statusResult = result.Should().BeOfType<ObjectResult>().Which;
+        statusResult.StatusCode.Should().Be(201);
+        var widgets = statusResult.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(1);
+        widgets[0].Name.Should().Be("Gadget");
+        widgets[0].Sku.Should().Be("GAD-001");
+        widgets[0].Quantity.Should().Be(5);
+        widgets[0].Id.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task BulkCreate_with_exactly_50_items_returns_201()
+    {
+        var controller = BuildController();
+        var requests = Enumerable.Range(1, 50)
+            .Select(i => new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var statusResult = result.Should().BeOfType<ObjectResult>().Which;
+        statusResult.StatusCode.Should().Be(201);
+        var widgets = statusResult.Value.Should().BeAssignableTo<IReadOnlyList<Widget>>().Which;
+        widgets.Should().HaveCount(50);
+    }
+
+    // AC-2 / AC-6: oversized batch returns 400 with error.code == "batch_size_exceeded"
+    [Fact]
+    public async Task BulkCreate_with_51_items_returns_400_with_batch_size_exceeded_code()
+    {
+        var controller = BuildController();
+        var requests = Enumerable.Range(1, 51)
+            .Select(i => new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Which;
+        var body = badRequest.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        errorProp.Should().NotBeNull();
+        var errorValue = errorProp!.GetValue(body)!;
+        var codeProp = errorValue.GetType().GetProperty("code");
+        codeProp.Should().NotBeNull();
+        codeProp!.GetValue(errorValue).Should().Be("batch_size_exceeded");
+        var messageProp = errorValue.GetType().GetProperty("message");
+        messageProp.Should().NotBeNull();
+        ((string)messageProp!.GetValue(errorValue)!).Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(51)]
+    [InlineData(100)]
+    public async Task BulkCreate_with_batch_exceeding_max_returns_400_with_batch_size_exceeded_code(int count)
+    {
+        var controller = BuildController();
+        var requests = Enumerable.Range(1, count)
+            .Select(i => new CreateWidgetRequest($"Widget {i}", $"SKU-{i}", i))
+            .ToList();
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Which;
+        var body = badRequest.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        var errorValue = errorProp!.GetValue(body)!;
+        var codeProp = errorValue.GetType().GetProperty("code");
+        codeProp!.GetValue(errorValue).Should().Be("batch_size_exceeded");
+    }
+
+    // AC-3 / AC-6: invalid batch returns 422 with error.code == "batch_validation_failure" and non-empty error.failures
+    [Fact]
+    public async Task BulkCreate_with_one_invalid_item_returns_422_with_batch_validation_failure_code()
+    {
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest>
+        {
+            new("Valid Widget", "SKU-001", 5),
+            new("", "SKU-002", 5),           // blank name — index 1
+        };
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var unprocessable = result.Should().BeOfType<UnprocessableEntityObjectResult>().Which;
+        var body = unprocessable.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        errorProp.Should().NotBeNull();
+        var errorValue = errorProp!.GetValue(body)!;
+        var codeProp = errorValue.GetType().GetProperty("code");
+        codeProp!.GetValue(errorValue).Should().Be("batch_validation_failure");
+        var failuresProp = errorValue.GetType().GetProperty("failures");
+        failuresProp.Should().NotBeNull();
+        var failures = failuresProp!.GetValue(errorValue) as System.Array;
+        failures.Should().NotBeNull();
+        failures!.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task BulkCreate_with_invalid_item_returns_422_with_correct_index_in_failures()
+    {
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest>
+        {
+            new("Valid Widget", "SKU-001", 5),
+            new("Another Valid Widget", "SKU-002", 10),
+            new("Bad Widget", "SKU-003", -1),  // negative quantity — index 2
+        };
+
+        var result = await controller.BulkCreate(requests, CancellationToken.None);
+
+        var unprocessable = result.Should().BeOfType<UnprocessableEntityObjectResult>().Which;
+        var body = unprocessable.Value!;
+        var errorProp = body.GetType().GetProperty("error");
+        var errorValue = errorProp!.GetValue(body)!;
+        var failuresProp = errorValue.GetType().GetProperty("failures");
+        var failures = failuresProp!.GetValue(errorValue) as System.Array;
+        failures.Should().NotBeNull();
+        failures!.Length.Should().Be(1);
+
+        var firstFailure = failures.GetValue(0)!;
+        var indexProp = firstFailure.GetType().GetProperty("index");
+        indexProp.Should().NotBeNull();
+        indexProp!.GetValue(firstFailure).Should().Be(2);
+
+        var reasonProp = firstFailure.GetType().GetProperty("reason");
+        reasonProp.Should().NotBeNull();
+        ((string)reasonProp!.GetValue(firstFailure)!).Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task BulkCreate_with_invalid_items_does_not_persist_any_widgets()
+    {
+        // Use the real controller (InMemoryWidgetRepository) — verify GetCount stays zero
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest>
+        {
+            new("Valid Widget", "SKU-001", 5),
+            new("", "SKU-002", 5),  // blank name
+        };
+
+        await controller.BulkCreate(requests, CancellationToken.None);
+
+        var countResult = await controller.GetCount(CancellationToken.None);
+        var ok = countResult.Should().BeOfType<OkObjectResult>().Which;
+        ok.Value.Should().BeEquivalentTo(new { count = 0 });
+    }
+
+    [Fact]
+    public async Task BulkCreate_with_all_valid_items_persists_all_widgets()
+    {
+        var controller = BuildController();
+        var requests = new List<CreateWidgetRequest>
+        {
+            new("Widget A", "SKU-A", 1),
+            new("Widget B", "SKU-B", 2),
+        };
+
+        await controller.BulkCreate(requests, CancellationToken.None);
+
+        var countResult = await controller.GetCount(CancellationToken.None);
+        var ok = countResult.Should().BeOfType<OkObjectResult>().Which;
+        ok.Value.Should().BeEquivalentTo(new { count = 2 });
+    }
+}


### PR DESCRIPTION
FEAT-2026-0009/T01

## Summary

Adds the `POST /widgets/bulk` endpoint to `WidgetsController`, allowing clients to create up to 50 widgets in a single atomic request. Validation is performed across all items before any persistence occurs: a single failing item rejects the whole batch. Three new supporting types (`BulkCreateItem`, `BulkCreateFailure`, `BulkCreateResult`) encapsulate the service-layer contract cleanly without modifying any existing method signatures or the `IWidgetRepository` interface.

## Task

- Issue: Bontyyy/orchestrator-api-sample#29
- Feature: FEAT-2026-0009

## Verification

All six mandatory gates passing. Evidence in the `task_completed` event payload on the orchestration repo's `/events/FEAT-2026-0009.jsonl`.

- tests: pass (91/91 passed)
- coverage: pass (line coverage 0.9961, threshold 0.90)
- compiler_warnings: pass (0 warnings)
- lint: pass
- security_scan: pass (0 high, 0 critical findings)
- build: pass (Release build ok)

Per-task verification commands (all pass):
- `dotnet test --filter "FullyQualifiedName~BulkCreate"` → 26/26 passed
- `dotnet test --filter "FullyQualifiedName~Bulk"` → 26/26 passed
- `grep -F "HttpPost"` → `[HttpPost]` and `[HttpPost("bulk")]` present
- `grep -F "bulk"` → `[HttpPost("bulk")]` and `BulkCreate` method present
- `grep -F "batch_validation_failure"` → literal string present
- `grep -F "batch_size_exceeded"` → literal string present
- `grep -F "failures"` → `failures` array present in response body

## Spec issues raised during execution

none

## Overrides applied

none