### PR TITLE
fix(widgets): separate validation and persistence loops in BulkCreateAsync

### DIFF
--- a/src/OrchestratorApiSample.Application/Services/WidgetService.cs
+++ b/src/OrchestratorApiSample.Application/Services/WidgetService.cs
@@ -99,9 +99,8 @@ public sealed class WidgetService
             return BulkCreateResult.BatchSizeExceeded(items.Count, BulkCreateMaxBatchSize);
         }
 
-        // Validate and persist items.
+        // Pass 1: validate ALL items before persisting any.
         var failures = new List<BulkCreateFailure>();
-        var created = new List<Widget>(items.Count);
         for (var i = 0; i < items.Count; i++)
         {
             var item = items[i];
@@ -121,21 +120,25 @@ public sealed class WidgetService
             {
                 failures.Add(new BulkCreateFailure(i, "quantity must be at most 10000"));
             }
-            else
-            {
-                var widget = new Widget(
-                    Id: Guid.NewGuid().ToString("N"),
-                    Name: item.Name.Trim(),
-                    Sku: item.Sku.Trim(),
-                    Quantity: item.Quantity);
-                var stored = await _repository.AddAsync(widget, cancellationToken);
-                created.Add(stored);
-            }
         }
 
         if (failures.Count > 0)
         {
             return BulkCreateResult.ValidationFailure(failures);
+        }
+
+        // Pass 2: all items are valid — persist them all.
+        var created = new List<Widget>(items.Count);
+        for (var i = 0; i < items.Count; i++)
+        {
+            var item = items[i];
+            var widget = new Widget(
+                Id: Guid.NewGuid().ToString("N"),
+                Name: item.Name.Trim(),
+                Sku: item.Sku.Trim(),
+                Quantity: item.Quantity);
+            var stored = await _repository.AddAsync(widget, cancellationToken);
+            created.Add(stored);
         }
 
         return BulkCreateResult.Success(created);


### PR DESCRIPTION
FEAT-2026-0009/T05

## Summary

Restores the correct two-pass pattern in `WidgetService.BulkCreateAsync`: validate all items first, collect all failures, and only persist if there are zero failures. The previous single interleaved loop called `_repository.AddAsync()` for valid items before detecting invalid ones later in the batch, violating AC-3's atomicity guarantee.

## Task

- Issue: Bontyyy/orchestrator-api-sample#34
- Feature: FEAT-2026-0009 — Bulk widget creation endpoint

## Verification

All six mandatory gates passing. Evidence in the `task_completed` event payload on the orchestration repo's `/events/FEAT-2026-0009.jsonl`.

- tests: pass (91/91)
- coverage: pass (0.9961, threshold 0.90)
- compiler_warnings: pass (0 warnings)
- lint: pass
- security_scan: pass (0 high, 0 critical)
- build: pass (Release build ok)

## Spec issues raised during execution

none

## Overrides applied

none